### PR TITLE
Add support for more ether JS signers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ const web3Auth = new Web3Auth({
 
 const web3authProvider = await web3Auth.connectWith('google');
 
-const ethersProvider = new ethers.providers.Web3Provider(web3authProvider as any);
+const ethersProvider = new ethers.BrowserProvider(web3authProvider as any);
 const web3AuthSigner = ethersProvider.getSigner();
 
 const accountInstance = await Account.createInstance(web3AuthSigner, chainConfigs);

--- a/src/Account.ts
+++ b/src/Account.ts
@@ -1,4 +1,4 @@
-import { ethers, JsonRpcProvider } from 'ethers';
+import { ethers, JsonRpcProvider, Signer } from 'ethers';
 import { ENTRY_POINT, FACTORY, USER_AGENT } from './constants';
 import { Presets } from 'blndgs-userop';
 import { tokenToFloat, weiToFloat } from './utils';
@@ -11,7 +11,7 @@ export class Account {
    * Private constructor to enforce the use of factory methods for instantiation.
    * @param signer The ethers Signer used for transaction signing.
    */
-  private constructor(public signer: ethers.Signer) {}
+  private constructor(public signer: Signer) { }
 
   /**
    * Creates an instance of the Account class with associated chain configurations.
@@ -20,7 +20,10 @@ export class Account {
    * @param chainConfigs Configuration mapping chain IDs to their configurations.
    * @returns A new instance of the Account class populated with sender addresses and providers per chain.
    */
-  static async createInstance(signer: ethers.Signer, chainConfigs: ChainConfigs): Promise<Account> {
+  static async createInstance(
+    signer: Signer,
+    chainConfigs: ChainConfigs
+  ): Promise<Account> {
     const account = new Account(signer);
     await Promise.all(
       Object.entries(chainConfigs).map(async ([chainId, config]) => {
@@ -40,7 +43,11 @@ export class Account {
    * @param factory Optional factory address to interact with when generating the sender.
    * @returns The Ethereum address as a string.
    */
-  static async getSender(signer: ethers.Signer, bundlerUrl: string, salt: number = 0): Promise<string> {
+  static async getSender(
+    signer: Signer,
+    bundlerUrl: string,
+    salt: number = 0
+  ): Promise<string> {
     // Convert salt to a number, then to a hex string
     const simpleAccount = await Presets.Builder.SimpleAccount.init(signer, bundlerUrl, USER_AGENT, {
       factory: FACTORY,

--- a/src/Account.ts
+++ b/src/Account.ts
@@ -1,4 +1,4 @@
-import { ethers, JsonRpcProvider, Signer } from 'ethers';
+import { ethers, JsonRpcProvider } from 'ethers';
 import { ENTRY_POINT, FACTORY, USER_AGENT } from './constants';
 import { Presets } from 'blndgs-userop';
 import { tokenToFloat, weiToFloat } from './utils';
@@ -11,7 +11,7 @@ export class Account {
    * Private constructor to enforce the use of factory methods for instantiation.
    * @param signer The ethers Signer used for transaction signing.
    */
-  private constructor(public signer: Signer) { }
+  private constructor(public signer: ethers.Signer) { }
 
   /**
    * Creates an instance of the Account class with associated chain configurations.
@@ -20,10 +20,7 @@ export class Account {
    * @param chainConfigs Configuration mapping chain IDs to their configurations.
    * @returns A new instance of the Account class populated with sender addresses and providers per chain.
    */
-  static async createInstance(
-    signer: Signer,
-    chainConfigs: ChainConfigs
-  ): Promise<Account> {
+  static async createInstance(signer: ethers.Signer, chainConfigs: ChainConfigs): Promise<Account> {
     const account = new Account(signer);
     await Promise.all(
       Object.entries(chainConfigs).map(async ([chainId, config]) => {
@@ -43,11 +40,7 @@ export class Account {
    * @param factory Optional factory address to interact with when generating the sender.
    * @returns The Ethereum address as a string.
    */
-  static async getSender(
-    signer: Signer,
-    bundlerUrl: string,
-    salt: number = 0
-  ): Promise<string> {
+  static async getSender(signer: ethers.Signer, bundlerUrl: string, salt: number = 0): Promise<string> {
     // Convert salt to a number, then to a hex string
     const simpleAccount = await Presets.Builder.SimpleAccount.init(signer, bundlerUrl, USER_AGENT, {
       factory: FACTORY,


### PR DESCRIPTION
I also updated the example to include a webauth signer that can be used with the sdk as-is without any
changes to core functionality 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new authentication method using Web3Auth for the `intents.js` SDK.
	- Updated documentation with clear instructions for both Web3Auth and private key authentication methods.

- **Bug Fixes**
	- Improved variable naming consistency in the documentation.

- **Documentation**
	- Enhanced the README with detailed setup instructions for Web3Auth.
	- Clarified the section on executing intents and optional configurations.

- **Style**
	- Minor formatting adjustments in the `Account` class constructor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->